### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,23 @@
+name: Deploy Vite site to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Install deps
+        run: pnpm install
+      - name: Build
+        run: pnpm run build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/simple-ai-landing/README.md
+++ b/simple-ai-landing/README.md
@@ -14,3 +14,12 @@ Create `.env.local` with `NEXT_PUBLIC_GA_ID` to enable analytics.
 ## Deploy
 
 Deploy to Vercel or any platform running Next.js.
+
+## Deploy to GitHub Pages
+
+```bash
+# manual one-liner
+npm run deploy
+```
+
+or let the included GitHub Actions workflow do it automatically on each push to `main`.

--- a/simple-ai-landing/package.json
+++ b/simple-ai-landing/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "next": "15.0.0",
@@ -17,6 +19,7 @@
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.23",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "gh-pages": "^5.0.0"
   }
 }

--- a/simple-ai-landing/vite.config.ts
+++ b/simple-ai-landing/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  base: "/simpleai-landingpage/",
+});


### PR DESCRIPTION
## Summary
- add `gh-pages` deploy scripts
- create Vite config with GitHub Pages base path
- automate deploys with a GitHub Actions workflow
- document manual deploy command

## Testing
- `npm i -D gh-pages` *(fails: no network)*
- `npm install` *(fails: no network)*